### PR TITLE
feat: use --out option of license-checker

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,8 @@ class WebpackLicensePlugin {
       return `${name}@${packageJson.version}`
     })
 
+    const tempFileName = join(process.cwd(), 'temp.json')
+
     // run license-checker on the given package versions to find out
     // license information
     exec(
@@ -109,7 +111,7 @@ class WebpackLicensePlugin {
         packageMeta[0].path.split('node_modules')[0]
       }${
         this.blacklist.length ? ` --failOn '${this.blacklist.join(';')}'` : ''
-      } --packages '${packageVersions.join(';')}'`,
+      } --packages '${packageVersions.join(';')}' --out ${tempFileName}`,
       { maxBuffer: 1024 * 1024 * 10 }, // 10mb max buffer size
       async (err, stdout, stderr) => {
         if (err) {
@@ -128,12 +130,15 @@ class WebpackLicensePlugin {
 
         // convert license-checker information to an array and apply
         // overrides
-        const licenseInfo = getLicenseInfo(JSON.parse(stdout.toString())).map(
-          li => ({
-            ...li,
-            license: this.overrides[`${li.name}@${li.version}`] || li.license,
-          })
-        )
+        const licenseInfo = getLicenseInfo(
+          JSON.parse(fs.readFileSync(tempFileName, 'UTF-8'))
+        ).map(li => ({
+          ...li,
+          license: this.overrides[`${li.name}@${li.version}`] || li.license,
+        }))
+
+        // remove temporary file
+        fs.unlinkSync(tempFileName)
 
         // calculate summary
         const summary = getSummary(licenseInfo)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-license-plugin",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Extracts OSS license information of the npm packages in your webpack output",
   "keywords": [
     "webpack",


### PR DESCRIPTION
The stdout of `license-checker` sometimes contains characters before the actual json output is written. this causes problems parsing that output. In order to circumvent this, we make `license-checker` write it's json output to a file (which, opposed to the stdout, contains json **only**) and read from there.