### PR TITLE
Fix race condition, use `tapAsync` for `handleChunkAssetOptimization` hook

### DIFF
--- a/src/WebpackLicensePlugin.ts
+++ b/src/WebpackLicensePlugin.ts
@@ -44,7 +44,7 @@ export default class WebpackLicensePlugin implements IWebpackPlugin {
     compilation: webpack.compilation.Compilation
   ) {
     if (typeof compilation.hooks !== 'undefined') {
-      compilation.hooks.optimizeChunkAssets.tap(
+      compilation.hooks.optimizeChunkAssets.tapAsync(
         'webpack-license-plugin',
         this.handleChunkAssetOptimization.bind(this, compiler, compilation)
       )

--- a/test/unit/WebpackLicensePlugin.test.ts
+++ b/test/unit/WebpackLicensePlugin.test.ts
@@ -1,9 +1,11 @@
 import WebpackLicensePlugin from '../../src/WebpackLicensePlugin'
 import webpack = require('webpack')
 
-const MockCompiler = jest.fn<webpack.Compiler, any[]>(i => i)
-const MockCompilation = jest.fn<webpack.compilation.Compilation, any[]>(i => i)
-const MockChunk = jest.fn<webpack.compilation.Chunk, any[]>(i => i)
+const MockCompiler = jest.fn<webpack.Compiler, any[]>((i) => i)
+const MockCompilation = jest.fn<webpack.compilation.Compilation, any[]>(
+  (i) => i
+)
+const MockChunk = jest.fn<webpack.compilation.Chunk, any[]>((i) => i)
 
 describe('WebpackLicensePlugin', () => {
   describe('apply', () => {
@@ -38,15 +40,16 @@ describe('WebpackLicensePlugin', () => {
     test('taps into optimizeChunkAssets hook if hooks are defined', () => {
       const instance = new WebpackLicensePlugin()
       const compilation = new MockCompilation({
-        hooks: { optimizeChunkAssets: { tap: jest.fn() } },
+        hooks: { optimizeChunkAssets: { tap: jest.fn(), tapAsync: jest.fn() } },
       })
       instance.handleCompilation(new MockCompiler(), compilation)
 
-      expect(compilation.hooks.optimizeChunkAssets.tap).toHaveBeenCalledTimes(1)
-      expect(compilation.hooks.optimizeChunkAssets.tap).toHaveBeenCalledWith(
-        'webpack-license-plugin',
-        expect.any(Function)
-      )
+      expect(
+        compilation.hooks.optimizeChunkAssets.tapAsync
+      ).toHaveBeenCalledTimes(1)
+      expect(
+        compilation.hooks.optimizeChunkAssets.tapAsync
+      ).toHaveBeenCalledWith('webpack-license-plugin', expect.any(Function))
     })
 
     test('plugs into optimize-chunk-assets otherwise', () => {


### PR DESCRIPTION
I've encountered a race condition where the build was not failing on unacceptable licenses. `tapAsync` seems to be a proper function to use when the plugin hook return promise.