### PR TITLE
feat: Add includePackages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The available options are:
 | **`outputFilename`** | Default: `oss-licenses.json`. Path to the output file that will be generated. Relative to the bundle output directory. |
 | **`replenishDefaultLicenseTexts`** | Default: `false`. When this is enabled, default license texts are taken from spdx.org for packages where no license text was found. |
 | **`unacceptableLicenseTest`** | A method to define license identifiers as unacceptable. It is invoked with `licenseIdentifier` (string) for every package and should return true when the license is unacceptable and encountering it should fail the build. |
+| **`includePackages`** | Default: `() => []`. A method to define packages that should always be included in the output. It must return an array containing the absolute paths of those packages. This function can be async or return a Promise.
 
 ### Example with custom options
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "main": "./dist/index.js",
   "author": "Christoph Werner <christoph@codepunkt.de>",
   "contributors": [
-    "Friedrich Wilms <f.wilms89@web.de>"
+    "Friedrich Wilms <f.wilms89@web.de>",
+    "Tobias Trumm <info@tobiastrumm.de>"
   ],
   "repository": {
     "type": "git",

--- a/src/LicenseFileWriter.ts
+++ b/src/LicenseFileWriter.ts
@@ -16,8 +16,9 @@ export default class LicenseFileWriter {
     options: IPluginOptions
   ): Promise<void> {
     const moduleDirs = this.getModuleDirs(filenames)
+    const includePackages = await options.includePackages();
     const licenseMeta = await this.licenseMetaAggregator.aggregateMeta(
-      moduleDirs
+      [...moduleDirs, ...includePackages]
     )
 
     const fileContents = JSON.stringify(licenseMeta, null, 2)

--- a/src/LicenseFileWriter.ts
+++ b/src/LicenseFileWriter.ts
@@ -18,7 +18,7 @@ export default class LicenseFileWriter {
     const moduleDirs = this.getModuleDirs(filenames)
     const includePackages = await options.includePackages();
     const licenseMeta = await this.licenseMetaAggregator.aggregateMeta(
-      [...moduleDirs, ...includePackages]
+      [...new Set([...moduleDirs, ...includePackages])]
     )
 
     const fileContents = JSON.stringify(licenseMeta, null, 2)

--- a/src/OptionsProvider.ts
+++ b/src/OptionsProvider.ts
@@ -42,5 +42,14 @@ export default class OptionsProvider {
         `Invalid replenishDefaultLicenseTexts option: Not a boolean!`
       )
     }
+
+    if (
+      inputOptions.includePackages &&
+      typeof inputOptions.includePackages !== 'function'
+    ) {
+      this.alertAggregator.addError(
+        `Invalid includePackages option: Not a function!`
+      )
+    }
   }
 }

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -7,6 +7,7 @@ const defaultOptions: IPluginOptions = {
   replenishDefaultLicenseTexts: false,
   unacceptableLicenseTest: () => false,
   excludedPackageTest: () => false,
+  includePackages: () => []
 }
 
 export default defaultOptions

--- a/src/types/IPluginOptions.ts
+++ b/src/types/IPluginOptions.ts
@@ -11,4 +11,5 @@ export default interface IPluginOptions {
   replenishDefaultLicenseTexts: boolean
   unacceptableLicenseTest: (licenseIdentifier: string) => boolean
   excludedPackageTest: (packageName: string, packageVersion: string) => boolean
+  includePackages: () => string[] | Promise<string>
 }

--- a/src/types/IPluginOptions.ts
+++ b/src/types/IPluginOptions.ts
@@ -11,5 +11,5 @@ export default interface IPluginOptions {
   replenishDefaultLicenseTexts: boolean
   unacceptableLicenseTest: (licenseIdentifier: string) => boolean
   excludedPackageTest: (packageName: string, packageVersion: string) => boolean
-  includePackages: () => string[] | Promise<string>
+  includePackages: () => string[] | Promise<string[]>
 }

--- a/test/e2e/__snapshots__/index.test.ts.snap
+++ b/test/e2e/__snapshots__/index.test.ts.snap
@@ -413,6 +413,234 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]
 `;
 
+exports[`end to end webpack v2 output matches snapshot when packages have been included 1`] = `
+Array [
+  Object {
+    "license": "MIT",
+    "licenseText": null,
+    "name": "jest",
+    "repository": "https://github.com/facebook/jest",
+    "source": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+    "version": "24.9.0",
+  },
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "author": "Roman Shtylman <shtylman@gmail.com>",
+    "license": "MIT",
+    "licenseText": "(The MIT License)
+
+Copyright (c) 2013 Roman Shtylman <shtylman@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "process",
+    "repository": "https://github.com/shtylman/node-process",
+    "source": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+    "version": "0.11.10",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) 2013-present, Facebook, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "prop-types",
+    "repository": null,
+    "source": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+    "version": "15.6.2",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Tobias Koppers @sokra",
+    "license": "MIT",
+    "licenseText": "Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "webpack",
+    "repository": "https://github.com/webpack/webpack",
+    "source": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+    "version": "2.7.0",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
 exports[`end to end webpack v2 output to a different outputFilename matches snapshot 1`] = `
 Array [
   Object {
@@ -1046,6 +1274,234 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]
 `;
 
+exports[`end to end webpack v3 output matches snapshot when packages have been included 1`] = `
+Array [
+  Object {
+    "license": "MIT",
+    "licenseText": null,
+    "name": "jest",
+    "repository": "https://github.com/facebook/jest",
+    "source": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+    "version": "24.9.0",
+  },
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "author": "Roman Shtylman <shtylman@gmail.com>",
+    "license": "MIT",
+    "licenseText": "(The MIT License)
+
+Copyright (c) 2013 Roman Shtylman <shtylman@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "process",
+    "repository": "https://github.com/shtylman/node-process",
+    "source": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+    "version": "0.11.10",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) 2013-present, Facebook, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "prop-types",
+    "repository": null,
+    "source": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+    "version": "15.6.2",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Tobias Koppers @sokra",
+    "license": "MIT",
+    "licenseText": "Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "webpack",
+    "repository": "https://github.com/webpack/webpack",
+    "source": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
+    "version": "3.12.0",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
 exports[`end to end webpack v3 output to a different outputFilename matches snapshot 1`] = `
 Array [
   Object {
@@ -1559,6 +2015,174 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]
 `;
 
+exports[`end to end webpack v4 output matches snapshot when packages have been included 1`] = `
+Array [
+  Object {
+    "license": "MIT",
+    "licenseText": null,
+    "name": "jest",
+    "repository": "https://github.com/facebook/jest",
+    "source": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+    "version": "24.9.0",
+  },
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Tobias Koppers @sokra",
+    "license": "MIT",
+    "licenseText": "Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "webpack",
+    "repository": "https://github.com/webpack/webpack",
+    "source": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+    "version": "4.43.0",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
 exports[`end to end webpack v4 output to a different outputFilename matches snapshot 1`] = `
 Array [
   Object {
@@ -1883,6 +2507,145 @@ THE SOFTWARE.
     "repository": null,
     "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
     "version": "4.1.1",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
+exports[`end to end webpack v5 output matches snapshot when packages have been included 1`] = `
+Array [
+  Object {
+    "license": "MIT",
+    "licenseText": null,
+    "name": "jest",
+    "repository": "https://github.com/facebook/jest",
+    "source": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+    "version": "24.9.0",
+  },
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
   },
   Object {
     "license": "MIT",

--- a/test/e2e/__snapshots__/index.test.ts.snap
+++ b/test/e2e/__snapshots__/index.test.ts.snap
@@ -222,6 +222,226 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]
 `;
 
+exports[`end to end webpack v2 output matches snapshot when a package has been manually included that is also included in the build result 1`] = `
+Array [
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "author": "Roman Shtylman <shtylman@gmail.com>",
+    "license": "MIT",
+    "licenseText": "(The MIT License)
+
+Copyright (c) 2013 Roman Shtylman <shtylman@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "process",
+    "repository": "https://github.com/shtylman/node-process",
+    "source": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+    "version": "0.11.10",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) 2013-present, Facebook, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "prop-types",
+    "repository": null,
+    "source": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+    "version": "15.6.2",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Tobias Koppers @sokra",
+    "license": "MIT",
+    "licenseText": "Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "webpack",
+    "repository": "https://github.com/webpack/webpack",
+    "source": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+    "version": "2.7.0",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
 exports[`end to end webpack v2 output matches snapshot when packages have been excluded 1`] = `
 Array [
   Object {
@@ -864,6 +1084,226 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 exports[`end to end webpack v3 additionalFiles match snapshot 1`] = `"[{\\"name\\":\\"webpack-license-plugin-test-example\\",\\"version\\":\\"1.0.0\\",\\"author\\":\\"Christoph Werner <christoph@codepunkt.de>\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":null},{\\"name\\":\\"webpack\\",\\"version\\":\\"3.12.0\\",\\"author\\":\\"Tobias Koppers @sokra\\",\\"repository\\":\\"https://github.com/webpack/webpack\\",\\"source\\":\\"https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"Copyright JS Foundation and other contributors\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining\\\\na copy of this software and associated documentation files (the\\\\n'Software'), to deal in the Software without restriction, including\\\\nwithout limitation the rights to use, copy, modify, merge, publish,\\\\ndistribute, sublicense, and/or sell copies of the Software, and to\\\\npermit persons to whom the Software is furnished to do so, subject to\\\\nthe following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be\\\\nincluded in all copies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\\\\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\\\\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\\\\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\\\\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\\\\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\\\\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\\\\n\\"},{\\"name\\":\\"scheduler\\",\\"version\\":\\"0.11.3\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) Facebook, Inc. and its affiliates.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"react-dom\\",\\"version\\":\\"16.6.3\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) Facebook, Inc. and its affiliates.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"react\\",\\"version\\":\\"16.6.3\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/react/-/react-16.6.3.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) Facebook, Inc. and its affiliates.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"prop-types\\",\\"version\\":\\"15.6.2\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) 2013-present, Facebook, Inc.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"process\\",\\"version\\":\\"0.11.10\\",\\"author\\":\\"Roman Shtylman <shtylman@gmail.com>\\",\\"repository\\":\\"https://github.com/shtylman/node-process\\",\\"source\\":\\"https://registry.npmjs.org/process/-/process-0.11.10.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"(The MIT License)\\\\n\\\\nCopyright (c) 2013 Roman Shtylman <shtylman@gmail.com>\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining\\\\na copy of this software and associated documentation files (the\\\\n'Software'), to deal in the Software without restriction, including\\\\nwithout limitation the rights to use, copy, modify, merge, publish,\\\\ndistribute, sublicense, and/or sell copies of the Software, and to\\\\npermit persons to whom the Software is furnished to do so, subject to\\\\nthe following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be\\\\nincluded in all copies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\\\\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\\\\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\\\\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\\\\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\\\\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\\\\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\\\\n\\"},{\\"name\\":\\"object-assign\\",\\"version\\":\\"4.1.1\\",\\"author\\":\\"Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"The MIT License (MIT)\\\\n\\\\nCopyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in\\\\nall copies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\\\\nTHE SOFTWARE.\\\\n\\"}]"`;
 
 exports[`end to end webpack v3 output matches snapshot 1`] = `
+Array [
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "author": "Roman Shtylman <shtylman@gmail.com>",
+    "license": "MIT",
+    "licenseText": "(The MIT License)
+
+Copyright (c) 2013 Roman Shtylman <shtylman@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "process",
+    "repository": "https://github.com/shtylman/node-process",
+    "source": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+    "version": "0.11.10",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) 2013-present, Facebook, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "prop-types",
+    "repository": null,
+    "source": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+    "version": "15.6.2",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Tobias Koppers @sokra",
+    "license": "MIT",
+    "licenseText": "Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "webpack",
+    "repository": "https://github.com/webpack/webpack",
+    "source": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
+    "version": "3.12.0",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
+exports[`end to end webpack v3 output matches snapshot when a package has been manually included that is also included in the build result 1`] = `
 Array [
   Object {
     "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
@@ -1884,6 +2324,166 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]
 `;
 
+exports[`end to end webpack v4 output matches snapshot when a package has been manually included that is also included in the build result 1`] = `
+Array [
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Tobias Koppers @sokra",
+    "license": "MIT",
+    "licenseText": "Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+",
+    "name": "webpack",
+    "repository": "https://github.com/webpack/webpack",
+    "source": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+    "version": "4.43.0",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
 exports[`end to end webpack v4 output matches snapshot when packages have been excluded 1`] = `
 Array [
   Object {
@@ -2346,6 +2946,137 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 exports[`end to end webpack v5 additionalFiles match snapshot 1`] = `"[{\\"name\\":\\"webpack-license-plugin-test-example\\",\\"version\\":\\"1.0.0\\",\\"author\\":\\"Christoph Werner <christoph@codepunkt.de>\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":null},{\\"name\\":\\"scheduler\\",\\"version\\":\\"0.11.3\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) Facebook, Inc. and its affiliates.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"react-dom\\",\\"version\\":\\"16.6.3\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) Facebook, Inc. and its affiliates.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"react\\",\\"version\\":\\"16.6.3\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/react/-/react-16.6.3.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"MIT License\\\\n\\\\nCopyright (c) Facebook, Inc. and its affiliates.\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in all\\\\ncopies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\\\\nSOFTWARE.\\\\n\\"},{\\"name\\":\\"object-assign\\",\\"version\\":\\"4.1.1\\",\\"author\\":\\"Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\\",\\"repository\\":null,\\"source\\":\\"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\\",\\"license\\":\\"MIT\\",\\"licenseText\\":\\"The MIT License (MIT)\\\\n\\\\nCopyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in\\\\nall copies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\\\\nTHE SOFTWARE.\\\\n\\"}]"`;
 
 exports[`end to end webpack v5 output matches snapshot 1`] = `
+Array [
+  Object {
+    "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",
+    "license": "MIT",
+    "licenseText": "The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+",
+    "name": "object-assign",
+    "repository": null,
+    "source": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "version": "4.1.1",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "react-dom",
+    "repository": null,
+    "source": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
+    "version": "16.6.3",
+  },
+  Object {
+    "license": "MIT",
+    "licenseText": "MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \\"Software\\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+",
+    "name": "scheduler",
+    "repository": null,
+    "source": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+    "version": "0.11.3",
+  },
+  Object {
+    "author": "Christoph Werner <christoph@codepunkt.de>",
+    "license": "MIT",
+    "licenseText": null,
+    "name": "webpack-license-plugin-test-example",
+    "repository": null,
+    "source": "https://registry.npmjs.org/webpack-license-plugin-test-example/-/webpack-license-plugin-test-example-1.0.0.tgz",
+    "version": "1.0.0",
+  },
+]
+`;
+
+exports[`end to end webpack v5 output matches snapshot when a package has been manually included that is also included in the build result 1`] = `
 Array [
   Object {
     "author": "Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)",

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -180,6 +180,30 @@ describe('end to end', () => {
           }
         )
       })
+
+      test('output matches snapshot when packages have been included', done => {
+        build(
+          new WebpackLicensePlugin({
+            includePackages: () => [
+              resolve(__dirname, '../../node_modules/jest')
+            ]
+          }),
+          fileSystem,
+          (err, stats) => {
+            const output = JSON.parse(
+              fileSystem
+                .readFileSync(`${outputPath}${sep}oss-licenses.json`)
+                .toString()
+            )
+
+            expect(err).toBe(null)
+            expect(output).not.toBe(null)
+            expect(output).toMatchSnapshot()
+
+            done()
+          }
+        )
+      })
     })
   })
 })

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -204,6 +204,30 @@ describe('end to end', () => {
           }
         )
       })
+
+      test('output matches snapshot when a package has been manually included that is also included in the build result', done => {
+        build(
+          new WebpackLicensePlugin({
+            includePackages: () => [
+              resolve(__dirname, 'example/node_modules/react')
+            ]
+          }),
+          fileSystem,
+          (err, stats) => {
+            const output = JSON.parse(
+              fileSystem
+                .readFileSync(`${outputPath}${sep}oss-licenses.json`)
+                .toString()
+            )
+
+            expect(err).toBe(null)
+            expect(output).not.toBe(null)
+            expect(output).toMatchSnapshot()
+
+            done()
+          }
+        )
+      })
     })
   })
 })

--- a/test/unit/OptionsProvider.test.ts
+++ b/test/unit/OptionsProvider.test.ts
@@ -78,5 +78,20 @@ describe('OptionsProvider', () => {
         'Invalid replenishDefaultLicenseTexts option: Not a boolean!'
       )
     })
+
+    test('errors on invalid type for includePackages option', () => {
+      const addError = jest.fn()
+      const instance = new OptionsProvider(
+        new MockAlertAggregator({ addError })
+      )
+
+      // @ts-ignore
+      instance.validateOptions({ includePackages: 'foo' })
+
+      expect(addError).toHaveBeenCalledTimes(1)
+      expect(addError).toHaveBeenCalledWith(
+        'Invalid includePackages option: Not a function!'
+      )
+    })
   })
 })


### PR DESCRIPTION
Closes #541 

I took a slightly different approach: Instead of of trying to resolve the package locations inside the webpack plugin, `includePackages` should contain a function that returns the absolute paths of the packages. This gives users more flexibility when including additional packages. They can directly link to the package inside their node_modules folder
```typescript
{
  includePackages: () => [
    // Assuming this config and node_modules are in the same directory
    path.join(__dirname, 'node_modules/some-package')
  ]
}
```
or use node to resolve the package location
```typescript
{
  includePackages: () => [
    path.dirname(require.resolve('some-package/package.json'))
  ]
}
```
This makes it even possible to point to packages inside other projects (might be relevant for some monorepo setups).