### PR TITLE
fix: conflict error

### DIFF
--- a/src/WebpackLicensePlugin.ts
+++ b/src/WebpackLicensePlugin.ts
@@ -23,7 +23,7 @@ const pluginName = 'WebpackLicensePlugin'
  * @todo preferred license types on ambiguity (licenses array or spdx expression)
  */
 export default class WebpackLicensePlugin implements IWebpackPlugin {
-  private filenames: string[] = []
+  private readonly filenames = new Set<string>()
 
   constructor(private pluginOptions: Partial<IPluginOptions> = {}) {}
 
@@ -71,7 +71,9 @@ export default class WebpackLicensePlugin implements IWebpackPlugin {
     alertAggregator.flushAlerts(pluginName)
 
     const chunkIterator = new WebpackChunkIterator()
-    this.filenames = [...this.filenames, ...chunkIterator.iterateChunks(compilation, chunks)]
+    for (const filename of chunkIterator.iterateChunks(compilation, chunks)) {
+      this.filenames.add(filename)
+    }
 
     if (compilation.compiler?.isChild()) {
       callback?.()
@@ -95,7 +97,7 @@ export default class WebpackLicensePlugin implements IWebpackPlugin {
       )
     )
 
-    await licenseFileWriter.writeLicenseFiles(this.filenames, options)
+    await licenseFileWriter.writeLicenseFiles([...this.filenames], options)
     alertAggregator.flushAlerts(pluginName)
 
     if (callback) {

--- a/test/unit/WebpackLicensePlugin.test.ts
+++ b/test/unit/WebpackLicensePlugin.test.ts
@@ -94,7 +94,7 @@ describe('WebpackLicensePlugin', () => {
           iterateChunks: () => ['filename1', 'filename2']
         }))
         .mockImplementationOnce(() => ({
-          iterateChunks: () => ['filename3', 'filename4']
+          iterateChunks: () => ['filename1', 'filename3', 'filename4']
         }))
 
       const writeLicenseFiles = jest.fn();


### PR DESCRIPTION
Like https://github.com/codepunkt/webpack-license-plugin/issues/581, https://github.com/codepunkt/webpack-license-plugin/issues/564 and https://github.com/codepunkt/webpack-license-plugin/issues/491 I recently ran into the `ERROR in Conflict: Multiple assets emit different content to the same filename` error. In my case it happend after I added the `mini-css-extract-plugin` to my webpack 5 config. After some experimenting I discovered that the error occurs when a combination of `mini-css-extract-plugin`, `html-webpack-plugin` and `webpack-license-plugin` is used (a full reproduction project can be found [here](https://github.com/WIStudent/webpack-license-plugin-conflict-issue)). It turns out that both `mini-css-extract-plugin` and `html-webpack-plugin` spawn child compilers and `webpack-license-plugin` gets called by them. My best guess is that the error occurs because there are now two child compilations each containing an asset called `oss-licenses.json` (you can see the contents of these in the reproduction project).

This PR fixes that by checking if `handleChunkAssetOptimization` is called by a child compiler. If that is the case, the `filenames` are saved but no files are being written yet. `writeLicenseFiles` is only called with the list of all filenames if the current compiler is the root compiler.