### PR TITLE
README suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-  <a href="https://github.com/codepunkt/webpack-license-plugin"><img src="https://raw.githubusercontent.com/codepunkt/webpack-license-plugin/master/docs/logo.png" alt="webpack-license-plugin logo" width="200"></a>
+  <a href="https://github.com/codepunkt/webpack-license-plugin"><img src="https://raw.githubusercontent.com/codepunkt/webpack-license-plugin/master/docs/logo.png" alt="" width="200"></a>
   <br>
   webpack-license-plugin
   <br>
@@ -39,7 +39,7 @@
 
 # Key features
 
-> This plugin extracts _open source license information_ about all of the npm packages in your webpack output and helps you identify and fix problems with your open source licensing policy.
+This plugin extracts _open source license information_ about all of the npm packages in your webpack output and helps you identify and fix problems with your open source licensing policy.
 
 This plugin has full test coverage and is tested with **webpack 2, 3, 4 and 5**. It will help you:
 
@@ -56,14 +56,14 @@ Install `webpack-license-plugin` as a development dependency to your current pro
 
 #### npm
 
-```bash
-npm install -D webpack-license-plugin
+```console
+$ npm install -D webpack-license-plugin
 ```
 
-#### yarn
+#### Yarn
 
-```bash
-yarn add -D webpack-license-plugin
+```console
+$ yarn add -D webpack-license-plugin
 ```
 
 # How to use


### PR DESCRIPTION
* Remove `alt` text from the logo as the title is in plaintext beneath it make the logo decorative; this just adds clutter for a11y
* `bash` blocks to `console` as these are not shell scripts but shell session (e.g. put this in your terminal)
* Remove improper use of blockquote; it is quoting nothing so it's improper markup
* Fix Yarn's casing

---

Other considerations:

* Go back to this being plaintext readable; the whole 'header' is full of HTML instead of of lightweight markup -- there is no syntactic need for `align=center`
* Move away from Markdown; AsciiDoc can give you image widths in its lightweight syntax, automatically generate a table of contents instead of manually managing--both of which can address the previous bullet