### PR TITLE
fix: main package not in output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "npm run dev",
+      "name": "Run npm dev",
+      "request": "launch",
+      "type": "node-terminal"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "test:unit": "jest --runInBand --testPathPattern test/unit --verbose",
     "test:watch": "jest --runInBand --testPathPattern test/unit --watch",
     "test:ci": "cross-env CI=true jest --runInBand --verbose --colors",
-    "posttest:ci": "codecov -t $CODECOV_TOKEN"
+    "posttest:ci": "codecov -t $CODECOV_TOKEN",
+    "dev": "npm run typescript && npm run debug -- --config test/e2e/webpack.config.js",
+    "debug": "node --inspect ./node_modules/webpack/bin/webpack.js"
   },
   "dependencies": {
     "chalk": "^5.0.1",

--- a/src/ModuleDirectoryLocator.ts
+++ b/src/ModuleDirectoryLocator.ts
@@ -11,7 +11,6 @@ import IPackageJsonReader from './types/IPackageJsonReader'
 export default class ModuleDirectoryLocator implements IModuleDirectoryLocator {
   constructor(
     private fileSystem: IFileSystem,
-    private buildRoot: string,
     private packageJsonReader: IPackageJsonReader
   ) {}
 
@@ -27,9 +26,7 @@ export default class ModuleDirectoryLocator implements IModuleDirectoryLocator {
     const checkParent = () =>
       this.checkModuleDir(resolve(`${moduleDir}${sep}..${sep}`), moduleDir)
 
-    const isNotPartOfPackage =
-      moduleDir === prevModuleDir || moduleDir === this.buildRoot
-    if (isNotPartOfPackage) {
+    if (moduleDir === prevModuleDir) {
       return null
     }
 

--- a/src/WebpackLicensePlugin.ts
+++ b/src/WebpackLicensePlugin.ts
@@ -126,11 +126,7 @@ export default class WebpackLicensePlugin implements IWebpackPlugin {
     const packageJsonReader = new PackageJsonReader(fileSystem)
     const licenseFileWriter = new LicenseFileWriter(
       new WebpackAssetManager(compilation),
-      new ModuleDirectoryLocator(
-        fileSystem,
-        compiler.options.context,
-        packageJsonReader
-      ),
+      new ModuleDirectoryLocator(fileSystem, packageJsonReader),
       new LicenseMetaAggregator(
         fileSystem,
         alertAggregator,


### PR DESCRIPTION
Fixes #845 

It also adds a debug script that allows attaching a debug session from VSCode (breakpoints, watchs, etc.) and a second script to debug using the example project configuration. To use press `F5` or open the Debug Panel in VSCode and run the `Run npm dev` script. 