### PR TITLE
feat: prefer module directory with license in package.json

### DIFF
--- a/test/unit/ModuleDirectoryLocator.test.ts
+++ b/test/unit/ModuleDirectoryLocator.test.ts
@@ -62,6 +62,46 @@ describe('ModuleDirectoryLocator', () => {
       )
     })
 
+    test('finds module dir where package.json license is set', () => {
+      const instance = new ModuleDirectoryLocator(
+        new FileSystem({
+          pathExists: p => {
+            return [
+              ...(isWin
+                ? [
+                  'C:\\project\\node_modules\\a\\package.json',
+                  'C:\\project\\node_modules\\a\\dist\\nolicense\\package.json',
+                ]
+                : [
+                  '/project/node_modules/a/package.json',
+                  '/project/node_modules/a/dist/nolicense/package.json',
+                ]),
+            ].includes(p)
+          },
+        }),
+        isWin ? 'C:\\project' : '/project',
+        new MockPackageJsonReader({
+          readPackageJson: path => {
+            if (path.endsWith('nolicense')) {
+              return { name: 'foo', version: '1.0.0' }
+            } else {
+              return { name: 'foo', version: '1.0.0', license: 'MIT' }
+            }
+          },
+        })
+      )
+
+      expect(
+        instance.getModuleDir(
+          isWin
+            ? 'C:\\project\\node_modules\\a\\dist\\nolicense\\index.js'
+            : '/project/node_modules/a/dist/nolicense/index.js'
+        )
+      ).toEqual(
+        isWin ? 'C:\\project\\node_modules\\a' : '/project/node_modules/a'
+      )
+    })
+
     test('returns null for own sources', () => {
       const instance = new ModuleDirectoryLocator(
         new FileSystem({


### PR DESCRIPTION
Change the behavior when locating the module dir to prefer a directory where the `package.json` has `license` or `licenses` set. Otherwise if no `package.json` exists that meets this criteria, fallback to previous behaviour (returning the closest `package.json` to the import that has a `name` and `version`.

I also refactored the `checkModuleDir` to not be recursive, to make this change a bit easier. Hope that's ok, thanks!

Resolves #908