### PR TITLE
feat: prefer `package.json` with license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "contributors": [
     "Friedrich Wilms <f.wilms89@web.de>",
     "Tobias Trumm <info@tobiastrumm.de>",
-    "Sebastian Peralta Friedburg <sebaspf@gmail.com>"
+    "Sebastian Peralta Friedburg <sebaspf@gmail.com>",
+    "Mike Peters <mpeters@boundstatesoftware.com>"
   ],
   "engines": {
     "node": ">=12.0.0"

--- a/src/ModuleDirectoryLocator.ts
+++ b/src/ModuleDirectoryLocator.ts
@@ -21,34 +21,37 @@ export default class ModuleDirectoryLocator implements IModuleDirectoryLocator {
   }
 
   private checkModuleDir(moduleDir: string): string | null {
-    let dirWithVersion: string | null = null;
-    let dirWithLicense: string | null = null;
-    let prevModuleDir: string | null = null;
+    let dirWithVersion: string | null = null
+    let dirWithLicense: string | null = null
+    let prevModuleDir: string | null = null
 
     do {
       if (this.fileSystem.pathExists(`${moduleDir}${sep}package.json`)) {
-        const packageMeta = this.packageJsonReader.readPackageJson(moduleDir);
+        const packageMeta = this.packageJsonReader.readPackageJson(moduleDir)
 
-        if (packageMeta.name !== undefined && packageMeta.version !== undefined) {
-          dirWithVersion = moduleDir;
+        if (
+          packageMeta.name !== undefined &&
+          packageMeta.version !== undefined
+        ) {
+          dirWithVersion = moduleDir
 
           if (
             packageMeta.license !== undefined ||
             packageMeta.licenses !== undefined
           ) {
-            dirWithLicense = moduleDir;
+            dirWithLicense = moduleDir
           }
         }
       }
 
-      prevModuleDir = moduleDir;
-      moduleDir = resolve(`${moduleDir}${sep}..${sep}`);
+      prevModuleDir = moduleDir
+      moduleDir = resolve(`${moduleDir}${sep}..${sep}`)
     } while (
       !dirWithLicense &&
       moduleDir !== prevModuleDir &&
       moduleDir !== this.buildRoot
-    );
+    )
 
-    return dirWithLicense || dirWithVersion;
+    return dirWithLicense || dirWithVersion
   }
 }

--- a/test/unit/ModuleDirectoryLocator.test.ts
+++ b/test/unit/ModuleDirectoryLocator.test.ts
@@ -63,6 +63,46 @@ describe('ModuleDirectoryLocator', () => {
       )
     })
 
+    test('finds module dir where package.json license is set', () => {
+      const instance = new ModuleDirectoryLocator(
+        new FileSystem({
+          pathExists: p => {
+            return [
+              ...(isWin
+                ? [
+                  'C:\\project\\node_modules\\a\\package.json',
+                  'C:\\project\\node_modules\\a\\dist\\nolicense\\package.json',
+                ]
+                : [
+                  '/project/node_modules/a/package.json',
+                  '/project/node_modules/a/dist/nolicense/package.json',
+                ]),
+            ].includes(p)
+          },
+        }),
+        isWin ? 'C:\\project' : '/project',
+        new MockPackageJsonReader({
+          readPackageJson: path => {
+            if (path.endsWith('nolicense')) {
+              return { name: 'foo', version: '1.0.0' }
+            } else {
+              return { name: 'foo', version: '1.0.0', license: 'MIT' }
+            }
+          },
+        })
+      )
+
+      expect(
+        instance.getModuleDir(
+          isWin
+            ? 'C:\\project\\node_modules\\a\\dist\\nolicense\\index.js'
+            : '/project/node_modules/a/dist/nolicense/index.js'
+        )
+      ).toEqual(
+        isWin ? 'C:\\project\\node_modules\\a' : '/project/node_modules/a'
+      )
+    })
+
     test('returns null for own sources', () => {
       const instance = new ModuleDirectoryLocator(
         new FileSystem({

--- a/test/unit/ModuleDirectoryLocator.test.ts
+++ b/test/unit/ModuleDirectoryLocator.test.ts
@@ -66,23 +66,23 @@ describe('ModuleDirectoryLocator', () => {
     test('finds module dir where package.json license is set', () => {
       const instance = new ModuleDirectoryLocator(
         new FileSystem({
-          pathExists: p => {
+          pathExists: (p) => {
             return [
               ...(isWin
                 ? [
-                  'C:\\project\\node_modules\\a\\package.json',
-                  'C:\\project\\node_modules\\a\\dist\\nolicense\\package.json',
-                ]
+                    'C:\\project\\node_modules\\a\\package.json',
+                    'C:\\project\\node_modules\\a\\dist\\nolicense\\package.json',
+                  ]
                 : [
-                  '/project/node_modules/a/package.json',
-                  '/project/node_modules/a/dist/nolicense/package.json',
-                ]),
+                    '/project/node_modules/a/package.json',
+                    '/project/node_modules/a/dist/nolicense/package.json',
+                  ]),
             ].includes(p)
           },
         }),
         isWin ? 'C:\\project' : '/project',
         new MockPackageJsonReader({
-          readPackageJson: path => {
+          readPackageJson: (path) => {
             if (path.endsWith('nolicense')) {
               return { name: 'foo', version: '1.0.0' }
             } else {


### PR DESCRIPTION
@mikejpeters I've cherry-picked your commit from #910 - thanks for your great work!

Change the behavior when locating the module dir to prefer a directory where the package.json has license or licenses set. Otherwise if no package.json exists that meets this criteria, fallback to previous behaviour (returning the closest package.json to the import that has a name and version.

I also refactored the checkModuleDir to not be recursive, to make this change a bit easier. Hope that's ok, thanks!

Resolves https://github.com/codepunkt/webpack-license-plugin/issues/908