### PR TITLE
fix: use updated SPDX main branch when replenishing licenses

### DIFF
--- a/src/DefaultLicenseTextProvider.ts
+++ b/src/DefaultLicenseTextProvider.ts
@@ -19,7 +19,7 @@ export default class DefaultLicenseTextProvider {
 
   public async retrieveLicenseText(license: string): Promise<string | null> {
     if (!this.cache[license]) {
-      const res = await this.request(`${REPO_URL}/master/text/${license}.txt`)
+      const res = await this.request(`${REPO_URL}/main/text/${license}.txt`)
       this.cache[license] = res
     }
 

--- a/test/unit/DefaultLicenseTextProvider.test.ts
+++ b/test/unit/DefaultLicenseTextProvider.test.ts
@@ -62,7 +62,7 @@ describe('defaultLicenseTextProvider', () => {
     expect(result).toBe(null)
     expect(mockRequest).toHaveBeenCalledTimes(1)
     expect(mockRequest).toHaveBeenCalledWith(
-      `${REPO_URL}/master/text/${unknownLicenseName}.txt`,
+      `${REPO_URL}/main/text/${unknownLicenseName}.txt`,
     )
   })
 


### PR DESCRIPTION
First of all: thanks for this package - it saved me quite some time already!
A tiny issue I ran into when trying the `replenishDefaultLicenseTexts` option: the `master` branch is no longer available.